### PR TITLE
Allow more recent GHC and dependency versions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.12
+# version: 0.15.20221009
 #
-# REGENDATA ("0.12",["github","cabal.project"])
+# REGENDATA ("0.15.20221009",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,58 +23,107 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.2.4
+            compilerKind: ghc
+            compilerVersion: 9.2.4
+            setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.4
+          - compiler: ghc-9.0.2
+            compilerKind: ghc
+            compilerVersion: 9.0.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-8.10.7
+            compilerKind: ghc
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.2.2
+            compilerKind: ghc
+            compilerVersion: 8.2.2
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y $CC cabal-install-3.4
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          fi
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HCDIR=$(echo "/opt/$CC" | sed 's/-/\//')
-          HCNAME=ghc
-          HC=$HCDIR/bin/$HCNAME
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=$HCDIR/bin/$HCNAME-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=$HCDIR/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--$HCNAME --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -96,6 +145,10 @@ jobs:
             prefix: $CABAL_DIR
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
+          EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
           EOF
           cat $CABAL_CONFIG
       - name: versions
@@ -135,7 +188,8 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_aws_lambda_runtime="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/aws-lambda-runtime-[0-9.]*')"
-          echo "PKGDIR_aws_lambda_runtime=${PKGDIR_aws_lambda_runtime}" >> $GITHUB_ENV
+          echo "PKGDIR_aws_lambda_runtime=${PKGDIR_aws_lambda_runtime}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_aws_lambda_runtime}" >> cabal.project
@@ -173,7 +227,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/aws-lambda-runtime.cabal
+++ b/aws-lambda-runtime.cabal
@@ -18,7 +18,7 @@ license-file:  LICENSE
 author:        Oleg Grenrus <oleg.grenrus@iki.fi>
 maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
 copyright:     (c) 2018 Futurice, 2018-2021 Oleg Grenrus
-tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
+tested-with:   GHC ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.4
 
 source-repository head
   type:     git
@@ -34,17 +34,17 @@ library
 
   -- GHC boot libraries
   build-depends:
-    , base        ^>=4.10.1.0 || ^>=4.11.1.0 || ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0 || ^>=4.15.0.0
-    , bytestring  ^>=0.10.8.2
+    , base        ^>=4.10.1.0 || ^>=4.11.1.0 || ^>=4.12.0.0 || ^>=4.13.0.0 || ^>=4.14.0.0 || ^>=4.15.0.0 || ^>=4.16.0.0
+    , bytestring  ^>=0.10.8.2 || ^>=0.11.0.0
     , containers  ^>=0.5.10.2 || ^>=0.6.0.1
     , deepseq     ^>=1.4.3.0
-    , text        ^>=1.2.3.0
+    , text        ^>=1.2.3.0 || ^>=2.0.0
 
   -- other dependencies
   build-depends:
-    , aeson        ^>=1.4.2.0 || ^>=1.5.2.0
+    , aeson        ^>=1.4.2.0 || ^>=1.5.2.0 || ^>=2.0.0.0 || ^>=2.1.0.0
     , async        ^>=2.2.1
-    , base-compat  ^>=0.11.0
+    , base-compat  ^>=0.11.0 || ^>=0.12.0
     , http-client  ^>=0.6.4 || ^>=0.7.1
     , http-media   ^>=0.8.0.0
     , http-types   ^>=0.12.2
@@ -72,5 +72,5 @@ executable example-lambda
 
   -- additional dependencies
   build-depends:
-    , lens        ^>=4.18 || ^>=4.19.2 || ^>=5.0.1
-    , lens-aeson  ^>=1.1
+    , lens        ^>=4.18 || ^>=4.19.2 || ^>=5.0.1 || ^>=5.1.0 || ^>=5.2.0
+    , lens-aeson  ^>=1.1 || ^>=1.2

--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -1,57 +1,27 @@
-FROM amazonlinux:2.0.20181114
+FROM amazonlinux:2.0.20221004.0
 
 # dependencies
 RUN yum -y install tar xz perl gcc make gmp gmp-devel zlib zlib-devel pkgconfig
 
-# GHC
-RUN mkdir -p /usr/src/ghc
-WORKDIR /usr/src/ghc
+# ghc and cabal
+RUN mkdir -p $HOME/.ghcup/bin \
+    && curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > $HOME/.ghcup/bin/ghcup \
+    && chmod a+x $HOME/.ghcup/bin/ghcup \
+    && $HOME/.ghcup/bin/ghcup install ghc 9.2.4 || (cat $HOME/.ghcup/logs/*.* && false) \
+    && $HOME/.ghcup/bin/ghcup install cabal 3.6.2.0 || (cat $HOME/.ghcup/logs/*.* && false) \
+    && ln -s $($HOME/.ghcup/bin/ghcup whereis ghc) $HOME/.ghcup/bin/ghc
+# ^ The above creation of ghc symlink seems like hack, but ghcup doesn't make ghc available on the path
 
-ENV GHCVER="8.4.4"
-ENV GHC_TGZ="ghc-8.4.4-x86_64-fedora27-linux.tar.xz"
+ENV PATH=/root/.ghcup/bin:/root/.cabal/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN curl --silent -O https://downloads.haskell.org/~ghc/$GHCVER/$GHC_TGZ \
-  && echo "8ab2befddc14d1434d0aad0c5d3c7e0c2b78ff84caa3429fa62527bfc6b86095  $GHC_TGZ" | sha256sum -c - \
-  && tar --strip-components=1 -xf $GHC_TGZ \
-  && rm $GHC_TGZ \
-  && ./configure --prefix=/opt/ghc \
-  && make install \
-  && rm -rf /usr/src/ghc \
-  && /opt/ghc/bin/ghc --version
+# cabal-plan
+RUN mkdir -p $HOME/.cabal/bin \
+    && curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz \
+    && echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c - \
+    && xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan \
+    && rm -f cabal-plan.xz \
+    && chmod a+x $HOME/.cabal/bin/cabal-plan
 
-# Cabal
-RUN mkdir -p /usr/src/cabal
-WORKDIR /usr/src/cabal
-
-ENV CABAL_VERSION="2.4.1.0"
-ENV CABAL_TGZ="cabal-install-2.4.1.0-x86_64-unknown-linux.tar.xz"
-
-RUN curl --silent -O http://downloads.haskell.org/cabal/cabal-install-$CABAL_VERSION/$CABAL_TGZ \
-  && tar -xf $CABAL_TGZ \
-  && rm $CABAL_TGZ \
-  && cp /usr/src/cabal/cabal /opt/ghc/bin \
-  && rm -rf /usr/src/cabal \
-  && /opt/ghc/bin/cabal --version
-
-ENV PATH=/root/.cabal/bin:/opt/ghc/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
-# Install cabal-plan
-#
-# - cabal update, new-install cabal-plan
-# - new-install creates symbolic link: copy over
-# - wipe all of ~/.cabal & ~/.ghc
-# - profit!
-
-RUN true \
-    && cabal new-update \
-    && cabal new-install cabal-plan --constraint=cabal-plan==0.4.0.0 --constraint='cabal-plan +exe' --symlink-bindir=/root/.cabal/bin \
-    && cp /root/.cabal/bin/$(readlink /root/.cabal/bin/cabal-plan) /root/cabal-plan \
-    && rm -rf /root/.cabal /root/.ghc \
-    && mkdir -p /root/.cabal/bin \
-    && mv /root/cabal-plan /root/.cabal/bin \
-    && ls -l /root/.cabal/bin \
-    && echo "cabal-plan installed"
-
-RUN ghc --version
-RUN cabal --version
-RUN cabal-plan --version
+RUN ghc --version \ 
+    && cabal --version \ 
+    && cabal-plan --version \


### PR DESCRIPTION
Hello @phadej 
I'm pretty excited I found this project!
For a long time we've been using [serverless-haskell](https://hackage.haskell.org/package/serverless-haskell) at work, but it's been getting problematic due to number of things lately. I like the lightweight nature, yet comprehensive features of this project (doesn't have amazonka as dep., doesn't use any js/typescript for packaging, includes build image + mocking functionality). Would you please be willing to help me bring the project up to date (or let me do it and just provide review) and then publish new version on hackage?